### PR TITLE
Handle dock & undock scenarios

### DIFF
--- a/DeskBand11/MainWindow.xaml
+++ b/DeskBand11/MainWindow.xaml
@@ -11,8 +11,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:winuiex="using:WinUIEx"
     Title="DeskBand11"
-    IsAlwaysOnTop="True"
     Closed="MainWindow_Closed"
+    IsAlwaysOnTop="True"
     mc:Ignorable="d">
 
     <Window.SystemBackdrop>

--- a/DeskBand11/MainWindow.xaml.cs
+++ b/DeskBand11/MainWindow.xaml.cs
@@ -3,8 +3,10 @@ using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.WindowsAndMessaging;
 using WinUIEx;
 
@@ -20,12 +22,29 @@ namespace DeskBand11
         IRecipient<OpenSettingsMessage>,
         IRecipient<QuitMessage>
     {
+        private readonly uint WM_TASKBAR_RESTART;
+        private readonly uint UxdDisplayChangeMessage;
+        private readonly uint HotplugDetected;
         private readonly HWND _hwnd;
         private readonly TrayIconService _trayIconService = new();
+        private AppWindow _appWindow;
+
+        // Constants for Windows messages related to display changes
+        private const int WM_DISPLAYCHANGE = 0x007E;
+        private const int WM_SETTINGCHANGE = 0x001A;
+
+        // Store the original WndProc
+        private WNDPROC? _originalWndProc;
+        private WNDPROC? _hotkeyWndProc;
 
         public MainWindow()
         {
             InitializeComponent();
+
+            WM_TASKBAR_RESTART = PInvoke.RegisterWindowMessage("TaskbarCreated");
+            UxdDisplayChangeMessage = PInvoke.RegisterWindowMessage("UxdDisplayChangeMessage");
+            HotplugDetected = PInvoke.RegisterWindowMessage("HotplugDetected");
+
             _hwnd = new HWND(WinRT.Interop.WindowNative.GetWindowHandle(this).ToInt32());
 
             this.VisibilityChanged += MainWindow_VisibilityChanged;
@@ -34,8 +53,22 @@ namespace DeskBand11
 
             WeakReferenceMessenger.Default.Register<OpenSettingsMessage>(this);
             WeakReferenceMessenger.Default.Register<QuitMessage>(this);
+
+            _appWindow = this.AppWindow;
+
+            // Set up custom window procedure to listen for display changes
+
+            // LOAD BEARING: If you don't stick the pointer to HotKeyPrc into a
+            // member (and instead like, use a local), then the pointer we marshal
+            // into the WindowLongPtr will be useless after we leave this function,
+            // and our **WindProc will explode**.
+            _hotkeyWndProc = CustomWndProc;
+            nint hotKeyPrcPointer = Marshal.GetFunctionPointerForDelegate(_hotkeyWndProc);
+            _originalWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(PInvoke.SetWindowLongPtr(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, hotKeyPrcPointer));
+
             MoveToTaskbar();
             _trayIconService.SetupTrayIcon(true);
+
         }
 
         private void ItemsBar_SizeChanged(object sender, Microsoft.UI.Xaml.SizeChangedEventArgs e)
@@ -48,10 +81,92 @@ namespace DeskBand11
             MoveToTaskbar();
         }
 
+        //private void SetupDisplayChangeListener()
+        //{
+        //    // Get the current window procedure
+        //    nint currentWndProc = PInvoke.GetWindowLongPtr(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
+
+        //    // Create our custom window procedure delegate
+        //    _originalWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(currentWndProc);
+
+        //    // Set our custom window procedure
+        //    nint newWndProcPtr = Marshal.GetFunctionPointerForDelegate<WNDPROC>(CustomWndProc);
+        //    PInvoke.SetWindowLongPtr(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, newWndProcPtr);
+        //}
+
+        private LRESULT CustomWndProc(HWND hwnd, uint uMsg, WPARAM wParam, LPARAM lParam)
+        {
+            // Handle display change messages
+            if (uMsg == WM_DISPLAYCHANGE)
+            {
+                Debug.WriteLine("WM_DISPLAYCHANGE");
+                // Use dispatcher to ensure we're on the UI thread
+                DispatcherQueue.TryEnqueue(() => MoveToTaskbar());
+            }
+            //else if (uMsg == WM_SETTINGCHANGE)
+            //{
+            //    // Check if this is a display-related setting change
+            //    string? settingName = Marshal.PtrToStringUni(lParam);
+            //    if (settingName == "intl" || settingName == null)
+            //    {
+            //        // This might be a display-related change
+            //        Debug.WriteLine($"WM_SETTINGCHANGE({settingName})");
+            //        _ = Task.Delay(1000).ContinueWith((t) => DispatcherQueue.TryEnqueue(() => MoveToTaskbar()));
+
+            //    }
+            //}
+            else if (uMsg == WM_SETTINGCHANGE)
+            {
+                if (wParam == (uint)SYSTEM_PARAMETERS_INFO_ACTION.SPI_SETWORKAREA)
+                {
+                    Debug.WriteLine($"WM_SETTINGCHANGE(SPI_SETWORKAREA)");
+                    _ = Task.Delay(1000).ContinueWith((t) => DispatcherQueue.TryEnqueue(() => UpdateLayoutForDPI()));
+
+                }
+            }
+            //else if (uMsg == WM_TASKBAR_RESTART)
+            //{
+
+            //    Debug.WriteLine("WM_TASKBAR_RESTART");
+            //    DispatcherQueue.TryEnqueue(() => UpdateLayoutForDPI());
+            //}
+            //else if (uMsg == UxdDisplayChangeMessage)
+            //{
+
+            //    Debug.WriteLine("UxdDisplayChangeMessage");
+            //    DispatcherQueue.TryEnqueue(() => UpdateLayoutForDPI());
+            //}
+            //else if (uMsg == HotplugDetected)
+            //{
+
+            //    Debug.WriteLine("HotplugDetected");
+            //    DispatcherQueue.TryEnqueue(() => UpdateLayoutForDPI());
+            //}
+
+            // Call the original window procedure for all messages
+            return PInvoke.CallWindowProc(_originalWndProc, hwnd, uMsg, wParam, lParam);
+        }
+        private async Task UpdateLayoutForDPI()
+        {
+            MoveToTaskbar();
+
+            await Task.Delay(200);
+            MainContent.Padding = new Thickness(1);
+            await Task.Delay(10);
+            //await Task.Yield();
+            MainContent.Padding = new Thickness(0);
+        }
+
         private void MoveToTaskbar()
         {
+            if (_appWindow is null)
+            {
+                Debug.WriteLine("unexpectedly, AppWindow was null");
+                return;
+            }
+
             ExtendsContentIntoTitleBar = true;
-            AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
+            _appWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
 
             HWND thisWindow = _hwnd;
 
@@ -67,17 +182,27 @@ namespace DeskBand11
 
             RECT taskbarRect = new();
             PInvoke.GetWindowRect(taskbarWindow, out taskbarRect);
+            Debug.WriteLine($"taskbarRect: ({taskbarRect.X}, {taskbarRect.Y}), {taskbarRect.Size}");
 
             RECT reBarRect = new();
             PInvoke.GetWindowRect(reBarWindow, out reBarRect);
 
+            RECT newWindowRect = new();
+            newWindowRect.left = taskbarRect.left;
+            newWindowRect.top = reBarRect.top - taskbarRect.top;
+            newWindowRect.right = newWindowRect.left + (taskbarRect.right - taskbarRect.left);
+            newWindowRect.bottom = newWindowRect.top + (reBarRect.bottom - reBarRect.top);
+            Debug.WriteLine($"newWindowRect: ({newWindowRect.left}, {newWindowRect.top}), ({newWindowRect.right}, {newWindowRect.bottom})");
+
+            PInvoke.SetWindowRgn(_hwnd, HRGN.Null, true);
+
             PInvoke.SetWindowPos(thisWindow,
                          HWND.Null,
-                         taskbarRect.left,
-                         reBarRect.top - taskbarRect.top,
-                         taskbarRect.right - taskbarRect.left,
-                         reBarRect.bottom - reBarRect.top,
-                         0);
+                         newWindowRect.left,
+                         newWindowRect.top,
+                         newWindowRect.Width,
+                         newWindowRect.Height,
+                         SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
 
             ClipWindow();
         }
@@ -99,10 +224,19 @@ namespace DeskBand11
             Debug.WriteLine($"ActualWidth: {clipToElement.ActualWidth}");
             Debug.WriteLine($"scaledBounds.Width: {scaledBounds.Width} ({scaledBounds.Width / scaleFactor})");
 
-            PInvoke.SetWindowRgn(_hwnd,
-                PInvoke.CreateRectRgn(scaledBounds.left,
-                    scaledBounds.top, scaledBounds.right, scaledBounds.bottom),
-                    true);
+            Windows.Win32.Graphics.Gdi.HRGN hrgn = PInvoke.CreateRectRgn(scaledBounds.left,
+                    scaledBounds.top, scaledBounds.right, scaledBounds.bottom);
+            PInvoke.SetWindowRgn(_hwnd, hrgn, true);
+            //PInvoke.DeleteObject(hrgn);
+
+            //PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_HIDE);
+            //PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_SHOWNA);
+            //PInvoke.BringWindowToTop(_hwnd);
+            //if (_appWindow.Presenter is OverlappedPresenter p)
+            //{
+            //    p.IsAlwaysOnTop = false;
+            //    p.IsAlwaysOnTop = true;
+            //}
         }
 
         public void Receive(OpenSettingsMessage message)
@@ -120,6 +254,13 @@ namespace DeskBand11
 
         private void MainWindow_Closed(object sender, WindowEventArgs args)
         {
+            // // Restore original window procedure if we have one
+            // if (_originalWndProc != null)
+            // {
+            //     var originalWndProcPtr = Marshal.GetFunctionPointerForDelegate(_originalWndProc);
+            //     PInvoke.SetWindowLongPtr(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, originalWndProcPtr);
+            // }
+
             _trayIconService.Destroy();
             Environment.Exit(0);
         }

--- a/DeskBand11/NativeMethods.txt
+++ b/DeskBand11/NativeMethods.txt
@@ -59,11 +59,14 @@ SetParent
 FindWindow
 FindWindowEx
 GetWindowLong
+GetWindowLongPtr
 SetWindowLong
 SetWindowPos
 WINDOW_STYLE
 SetWindowRgn
 CreateRectRgn
+SYSTEM_PARAMETERS_INFO_ACTION
+BringWindowToTop
 
 SHDefExtractIcon
 GetIconInfo

--- a/DeskBand11/cmdpal/TrayIconService.cs
+++ b/DeskBand11/cmdpal/TrayIconService.cs
@@ -183,6 +183,7 @@ internal sealed partial class TrayIconService
                     // Handle the case where explorer.exe restarts.
                     // Even if we created it before, do it again
                     SetupTrayIcon();
+                    WeakReferenceMessenger.Default.Send<TaskbarRestartMessage>(new());
                 }
                 else if (uMsg == WM_TRAY_ICON)
                 {


### PR DESCRIPTION
Listens for `WM_SETTINGCHANGE(SPI_SETWORKAREA)` to reposition our window back onto the taskbar. 

I tried to handle explorer crashing too, but that actually seems.... impossible?