### PR TITLE
Dodge the taskbar better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,7 +171,7 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/DeskBand11/BandsItemsControl.xaml
+++ b/DeskBand11/BandsItemsControl.xaml
@@ -85,7 +85,6 @@
                     <StackPanel
                         Grid.Column="0"
                         VerticalAlignment="Center"
-                        Background="Red"
                         Orientation="Vertical"
                         Visibility="{x:Bind HasIcon, Mode=OneWay}">
                         <cpcontrols:IconBox
@@ -102,7 +101,8 @@
                         Grid.Column="1"
                         VerticalAlignment="Center"
                         Background="Transparent"
-                        Orientation="Vertical">
+                        Orientation="Vertical"
+                        Visibility="{x:Bind HasText, Mode=OneWay}">
                         <TextBlock
                             x:Name="TitleTextBlock"
                             MaxWidth="200"
@@ -135,6 +135,7 @@
                     <ItemsRepeater
                         Grid.Column="2"
                         Margin="0,0,8,0"
+                        HorizontalAlignment="Left"
                         ItemTemplate="{StaticResource CommandButtonTemplate}"
                         ItemsSource="{x:Bind Buttons, Mode=OneWay}">
 
@@ -150,21 +151,57 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <ItemsControl
-        x:Name="ItemsBar"
-        Grid.Column="0"
-        MinWidth="200"
-        VerticalAlignment="Top"
-        Background="Blue"
-        BorderBrush="Blue"
-        BorderThickness="1"
-        IsTabStop="False"
-        ItemTemplate="{StaticResource DeskbandTemplate}"
-        ItemsSource="{x:Bind Bands, Mode=OneWay}">
-        <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-                <StackPanel Orientation="Horizontal" Spacing="16" />
-            </ItemsPanelTemplate>
-        </ItemsControl.ItemsPanel>
-    </ItemsControl>
+    <StackPanel Margin="0,0,8,0" Orientation="Horizontal">
+
+        <ItemsControl
+            x:Name="ItemsBar"
+            Grid.Column="0"
+            MinWidth="200"
+            VerticalAlignment="Top"
+            Background="Blue"
+            BorderBrush="Blue"
+            BorderThickness="1"
+            IsTabStop="False"
+            ItemTemplate="{StaticResource DeskbandTemplate}"
+            ItemsSource="{x:Bind Bands, Mode=OneWay}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="16" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+        </ItemsControl>
+
+        <Button Padding="4" Style="{StaticResource EllipsisButton}">
+            <Image
+                Width="24"
+                Height="32"
+                Source="/Assets/Deskband.png" />
+            <Button.Flyout>
+                <Flyout Placement="BottomEdgeAlignedRight" ShouldConstrainToRootBounds="False">
+                    <ItemsControl
+                        x:Name="ItemsFlyout"
+                        Grid.Column="0"
+                        MinWidth="200"
+                        MaxWidth="380"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Top"
+                        Background="Blue"
+                        BorderBrush="Blue"
+                        BorderThickness="1"
+                        IsTabStop="False"
+                        ItemTemplate="{StaticResource DeskbandTemplate}"
+                        ItemsSource="{x:Bind Bands, Mode=OneWay}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel
+                                    HorizontalAlignment="Left"
+                                    Orientation="Vertical"
+                                    Spacing="16" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </Flyout>
+            </Button.Flyout>
+        </Button>
+    </StackPanel>
 </UserControl>

--- a/DeskBand11/BandsItemsControl.xaml
+++ b/DeskBand11/BandsItemsControl.xaml
@@ -9,6 +9,7 @@
     xmlns:help="using:Microsoft.CmdPal.UI.Helpers"
     xmlns:local="using:DeskBand11"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    SizeChanged="OnSizeChanged"
     mc:Ignorable="d">
 
     <UserControl.Resources>
@@ -72,6 +73,85 @@
             </DataTemplate>
 
             <DataTemplate x:Key="DeskbandTemplate" x:DataType="local:TaskbarItemViewModel">
+                <Grid
+                    AutomationProperties.Name="{x:Bind Title, Mode=OneWay}"
+                    Background="Transparent"
+                    ColumnSpacing="8"
+                    Visibility="{x:Bind ShouldBeVisible, Mode=OneWay}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Orientation="Vertical"
+                        Visibility="{x:Bind HasIcon, Mode=OneWay}">
+                        <cpcontrols:IconBox
+                            x:Name="IconBorder"
+                            Width="32"
+                            Height="32"
+                            VerticalAlignment="Center"
+                            AutomationProperties.AccessibilityView="Raw"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            SourceKey="{x:Bind Icon, Mode=OneWay}"
+                            SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+                    </StackPanel>
+                    <StackPanel
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Background="Transparent"
+                        Orientation="Vertical"
+                        Visibility="{x:Bind HasText, Mode=OneWay}">
+                        <TextBlock
+                            x:Name="TitleTextBlock"
+                            MaxWidth="200"
+                            MaxHeight="40"
+                            Margin="0"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            CharacterSpacing="12"
+                            FontSize="14"
+                            Foreground="{ThemeResource TextFillColorPrimary}"
+                            Text="{x:Bind Title, Mode=OneWay}"
+                            TextAlignment="Left"
+                            TextTrimming="WordEllipsis"
+                            TextWrapping="NoWrap" />
+                        <TextBlock
+                            x:Name="SubTitleTextBlock"
+                            MaxWidth="152"
+                            MaxHeight="40"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center"
+                            CharacterSpacing="11"
+                            FontSize="10"
+                            Foreground="{ThemeResource TextFillColorTertiary}"
+                            Text="{x:Bind Subtitle, Mode=OneWay}"
+                            TextAlignment="Center"
+                            TextTrimming="WordEllipsis"
+                            TextWrapping="NoWrap" />
+                    </StackPanel>
+
+                    <ItemsRepeater
+                        Grid.Column="2"
+                        Margin="0,0,8,0"
+                        HorizontalAlignment="Left"
+                        ItemTemplate="{StaticResource CommandButtonTemplate}"
+                        ItemsSource="{x:Bind Buttons, Mode=OneWay}">
+
+                        <ItemsRepeater.Layout>
+                            <StackLayout
+                                x:Name="HorizontalStackLayout"
+                                Orientation="Horizontal"
+                                Spacing="8" />
+                        </ItemsRepeater.Layout>
+                    </ItemsRepeater>
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="FlyoutTemplate" x:DataType="local:TaskbarItemViewModel">
                 <Grid
                     AutomationProperties.Name="{x:Bind Title, Mode=OneWay}"
                     Background="Transparent"
@@ -171,7 +251,10 @@
             </ItemsControl.ItemsPanel>
         </ItemsControl>
 
-        <Button Padding="4" Style="{StaticResource EllipsisButton}">
+        <Button
+            x:Name="MoreButton"
+            Padding="4"
+            Style="{StaticResource EllipsisButton}">
             <Image
                 Width="24"
                 Height="32"
@@ -189,7 +272,7 @@
                         BorderBrush="Blue"
                         BorderThickness="1"
                         IsTabStop="False"
-                        ItemTemplate="{StaticResource DeskbandTemplate}"
+                        ItemTemplate="{StaticResource FlyoutTemplate}"
                         ItemsSource="{x:Bind Bands, Mode=OneWay}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>

--- a/DeskBand11/BandsItemsControl.xaml
+++ b/DeskBand11/BandsItemsControl.xaml
@@ -151,7 +151,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <StackPanel Margin="0,0,8,0" Orientation="Horizontal">
+    <StackPanel Margin="0,0,4,0" Orientation="Horizontal">
 
         <ItemsControl
             x:Name="ItemsBar"

--- a/DeskBand11/BandsItemsControl.xaml.cs
+++ b/DeskBand11/BandsItemsControl.xaml.cs
@@ -23,8 +23,8 @@ namespace DeskBand11
             // Add the TaskbarItemViewModel's you want here to extend the taskbar.
 
             // These two are testing samples
-            Bands.Add(new ButtonsWithLabelsTaskBand());
-            Bands.Add(new HelloWorldTaskBand());
+            //Bands.Add(new ButtonsWithLabelsTaskBand());
+            //Bands.Add(new HelloWorldTaskBand());
 
             // This is the AudioBand recreation
             Bands.Add(new AudioBand());

--- a/DeskBand11/BandsItemsControl.xaml.cs
+++ b/DeskBand11/BandsItemsControl.xaml.cs
@@ -20,8 +20,8 @@ namespace DeskBand11
             // Add the TaskbarItemViewModel's you want here to extend the taskbar.
 
             // These two are testing samples
-            // Bands.Add(new ButtonsWithLabelsTaskBand());
-            // Bands.Add(new HelloWorldTaskBand());
+            Bands.Add(new ButtonsWithLabelsTaskBand());
+            Bands.Add(new HelloWorldTaskBand());
 
             // This is the AudioBand recreation
             Bands.Add(new AudioBand());

--- a/DeskBand11/BandsItemsControl.xaml.cs
+++ b/DeskBand11/BandsItemsControl.xaml.cs
@@ -36,9 +36,17 @@ namespace DeskBand11
             Debug.WriteLine($"BandsItemsControl.ActualWidth={this.ActualWidth}");
         }
 
+        private void Trace(string s)
+        {
+            if (false)
+            {
+                Debug.WriteLine(s);
+            }
+        }
+
         public void SetMaxAvailableWidth(double availableSpace)
         {
-            Debug.WriteLine($"SetMaxAvailableWidth({availableSpace})");
+            Trace($"SetMaxAvailableWidth({availableSpace})");
 
             double neededSpace = 0.0;
             foreach (TaskbarItemViewModel item in BandsDisplayOrder)
@@ -52,16 +60,16 @@ namespace DeskBand11
                     //double w = fwe.ActualWidth;
                     double w = s.Width;
 
-                    Debug.WriteLine($"  '{item.Title}' needs: {w}");
+                    Trace($"  '{item.Title}' needs: {w}");
                     neededSpace += w;
                 }
             }
 
-            Debug.WriteLine($"  need: {neededSpace}");
+            Trace($"  need: {neededSpace}");
 
             if (neededSpace <= availableSpace)
             {
-                Debug.WriteLine($"  all fit");
+                Trace($"  all fit");
                 MoreButton.Visibility = Visibility.Collapsed;
                 foreach (TaskbarItemViewModel item in BandsDisplayOrder)
                 {
@@ -70,11 +78,11 @@ namespace DeskBand11
             }
             else
             {
-                Debug.WriteLine($"  don't all fit");
+                Trace($"  don't all fit");
                 MoreButton.Visibility = Visibility.Visible;
 
                 double takenSpace = MoreButton.Width;
-                Debug.WriteLine($"    button: {takenSpace}");
+                Trace($"    button: {takenSpace}");
                 foreach (TaskbarItemViewModel item in BandsDisplayOrder)
                 {
                     if (ItemsBar.ContainerFromItem(item) is FrameworkElement fwe)
@@ -82,10 +90,10 @@ namespace DeskBand11
                         Windows.Foundation.Size s = fwe.DesiredSize;
                         //double w = fwe.ActualWidth;
                         double w = s.Width;
-                        Debug.WriteLine($"    {item.Title}: {w + takenSpace}");
+                        Trace($"    {item.Title}: {w + takenSpace}");
                         if (takenSpace + w > availableSpace)
                         {
-                            Debug.WriteLine($"      hide");
+                            Trace($"      hide");
 
                             item.ShouldBeVisible = false;
                         }

--- a/DeskBand11/DeskBand11.csproj
+++ b/DeskBand11/DeskBand11.csproj
@@ -67,10 +67,32 @@
   </PropertyGroup>
 
   <!-- Publish Properties -->
-  <PropertyGroup>
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun>False</PublishReadyToRun>
+
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+    <DisableRuntimeMarshalling>false</DisableRuntimeMarshalling>
+
+    <PublishTrimmed>false</PublishTrimmed>
+    <PublishAot>false</PublishAot>
+
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
+
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+    <DisableRuntimeMarshalling>false</DisableRuntimeMarshalling>
+
+    <!-- <PublishTrimmed>true</PublishTrimmed> -->
+    <!-- <PublishAot>true</PublishAot> -->
   </PropertyGroup>
 </Project>

--- a/DeskBand11/MainWindow.xaml
+++ b/DeskBand11/MainWindow.xaml
@@ -36,7 +36,8 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition x:Name="WindowsLogo" Width="120" />
             <ColumnDefinition x:Name="TaskbarButtons" Width="0" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition x:Name="Mid" Width="*" />
+            <ColumnDefinition x:Name="ContentColumn" Width="Auto" />
             <ColumnDefinition x:Name="TrayIcons" Width="400" />
         </Grid.ColumnDefinitions>
 
@@ -49,12 +50,15 @@
             BorderBrush="Green"
             BorderThickness="2" />
 
-        <ContentControl x:Name="MainContent" Grid.Column="2">
+        <ContentControl
+            x:Name="MainContent"
+            Grid.Column="3"
+            HorizontalAlignment="Right">
             <local:BandsItemsControl />
         </ContentControl>
 
         <Border
-            Grid.Column="3"
+            Grid.Column="4"
             BorderBrush="Yellow"
             BorderThickness="2" />
 

--- a/DeskBand11/MainWindow.xaml
+++ b/DeskBand11/MainWindow.xaml
@@ -34,7 +34,7 @@
         </Grid.Resources>
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="WindowsLogo" Width="120" />
+            <ColumnDefinition x:Name="WindowsLogo" Width="60" />
             <ColumnDefinition x:Name="TaskbarButtons" Width="0" />
             <ColumnDefinition x:Name="Mid" Width="*" />
             <ColumnDefinition x:Name="ContentColumn" Width="Auto" />
@@ -54,7 +54,7 @@
             x:Name="MainContent"
             Grid.Column="3"
             HorizontalAlignment="Right">
-            <local:BandsItemsControl />
+            <local:BandsItemsControl x:Name="DeskbandsControl" />
         </ContentControl>
 
         <Border

--- a/DeskBand11/MainWindow.xaml
+++ b/DeskBand11/MainWindow.xaml
@@ -23,24 +23,40 @@
         x:Name="Root"
         Height="44"
         Margin="0,0,0,0"
-        HorizontalAlignment="Right"
+        HorizontalAlignment="Stretch"
         VerticalAlignment="Top"
         Background="Transparent"
         BorderBrush="Red"
-        BorderThickness="0">
+        BorderThickness="1">
 
         <Grid.Resources>
             <ResourceDictionary />
         </Grid.Resources>
 
         <Grid.ColumnDefinitions>
+            <ColumnDefinition x:Name="WindowsLogo" Width="120" />
+            <ColumnDefinition x:Name="TaskbarButtons" Width="0" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="400" />
+            <ColumnDefinition x:Name="TrayIcons" Width="400" />
         </Grid.ColumnDefinitions>
 
-        <ContentControl x:Name="MainContent" Grid.Column="0">
+        <Border
+            Grid.Column="0"
+            BorderBrush="Blue"
+            BorderThickness="2" />
+        <Border
+            Grid.Column="1"
+            BorderBrush="Green"
+            BorderThickness="2" />
+
+        <ContentControl x:Name="MainContent" Grid.Column="2">
             <local:BandsItemsControl />
         </ContentControl>
+
+        <Border
+            Grid.Column="3"
+            BorderBrush="Yellow"
+            BorderThickness="2" />
 
     </Grid>
 </winuiex:WindowEx>

--- a/DeskBand11/MainWindow.xaml
+++ b/DeskBand11/MainWindow.xaml
@@ -27,7 +27,7 @@
         VerticalAlignment="Top"
         Background="Transparent"
         BorderBrush="Red"
-        BorderThickness="1">
+        BorderThickness="0">
 
         <Grid.Resources>
             <ResourceDictionary />

--- a/DeskBand11/MainWindow.xaml
+++ b/DeskBand11/MainWindow.xaml
@@ -44,11 +44,11 @@
         <Border
             Grid.Column="0"
             BorderBrush="Blue"
-            BorderThickness="2" />
+            BorderThickness="0" />
         <Border
             Grid.Column="1"
             BorderBrush="Green"
-            BorderThickness="2" />
+            BorderThickness="0" />
 
         <ContentControl
             x:Name="MainContent"
@@ -60,7 +60,7 @@
         <Border
             Grid.Column="4"
             BorderBrush="Yellow"
-            BorderThickness="2" />
+            BorderThickness="0" />
 
     </Grid>
 </winuiex:WindowEx>

--- a/DeskBand11/MainWindow.xaml.cs
+++ b/DeskBand11/MainWindow.xaml.cs
@@ -46,11 +46,16 @@ namespace DeskBand11
 
         private double _lastContentSpace = 0;
 
+        private BandsItemsControl? _bandsControl;
+
         public MainWindow()
         {
             InitializeComponent();
 
             WM_TASKBAR_RESTART = PInvoke.RegisterWindowMessage("TaskbarCreated");
+
+            // Comment this out if you don't want to use the extensible deskbands
+            _bandsControl = DeskbandsControl;
 
             _hwnd = new HWND(WinRT.Interop.WindowNative.GetWindowHandle(this).ToInt32());
 
@@ -89,6 +94,7 @@ namespace DeskBand11
             _appWindow.TitleBar?.PreferredHeightOption = TitleBarHeightOption.Collapsed;
             MoveToTaskbar();
             _trayIconService.SetupTrayIcon(true);
+
 
         }
 
@@ -232,13 +238,14 @@ namespace DeskBand11
 
             double available = this.Bounds.Width; // Root.ActualWidth
 
-            int taskbarReserverdInDips = 120 + maxRight;
+            double taskbarReserverdInDips = WindowsLogo.Width.Value + maxRight; // WindowsLogo.Width.Value=60
             double forContent = available - taskbarReserverdInDips - TrayIcons.Width.Value;
             double reservedContent = WindowsLogo.ActualWidth + TaskbarButtons.ActualWidth /*+ Mid.ActualWidth*/ + TrayIcons.ActualWidth;
             double forContent2 = available - reservedContent;
 
             if (_lastContentSpace == forContent)
             {
+                _bandsControl?.SetMaxAvailableWidth(forContent);
                 return false;
             }
 
@@ -254,15 +261,18 @@ namespace DeskBand11
             {
                 ContentColumn.MaxWidth = Root.ActualWidth == 0 ? double.MaxValue : forContent;
                 ContentColumn.Width = GridLength.Auto;
+                _bandsControl?.SetMaxAvailableWidth(forContent);
             }
             else
             {
                 ContentColumn.MaxWidth = 0;
                 ContentColumn.Width = new GridLength(0);
+                _bandsControl?.SetMaxAvailableWidth(0);
             }
             _lastContentSpace = forContent;
             return true;
         }
+
         private void ClipWindow(bool onlyIfButtonsChanged = false)
         {
             bool taskbarChanged = UpdateTaskbarButtons();

--- a/DeskBand11/MainWindow.xaml.cs
+++ b/DeskBand11/MainWindow.xaml.cs
@@ -84,7 +84,7 @@ namespace DeskBand11
 
         private void ItemsBar_SizeChanged(object sender, Microsoft.UI.Xaml.SizeChangedEventArgs e)
         {
-            // ClipWindow();
+            ClipWindow();
         }
 
         private void MainWindow_VisibilityChanged(object sender, Microsoft.UI.Xaml.WindowVisibilityChangedEventArgs args)
@@ -158,16 +158,6 @@ namespace DeskBand11
                 return;
             }
 
-            _tasklist.Update();
-            List<TasklistButton> buttons = _tasklist.GetButtons();
-            int maxRight = 0;
-            foreach (TasklistButton button in buttons)
-            {
-                int right = button.X + button.Width;
-                if (right > maxRight) { maxRight = right; }
-            }
-            Debug.WriteLine($"maxRight: {maxRight}");
-            TaskbarButtons.Width = new GridLength(maxRight);
 
             HWND thisWindow = _hwnd;
 
@@ -205,11 +195,31 @@ namespace DeskBand11
                          newWindowRect.Height,
                          SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
 
-            //ClipWindow();
+            ClipWindow();
         }
 
         private void ClipWindow()
         {
+            _tasklist.Update();
+            List<TasklistButton> buttons = _tasklist.GetButtons();
+            int maxRight = 0;
+            foreach (TasklistButton button in buttons)
+            {
+                int right = button.X + button.Width;
+                if (right > maxRight) { maxRight = right; }
+            }
+            Debug.WriteLine($"maxRight: {maxRight}");
+            TaskbarButtons.Width = new GridLength(maxRight);
+
+            int taskbarReserverdInDips = 120 + maxRight;
+            double forContent = Root.ActualWidth - taskbarReserverdInDips - TrayIcons.Width.Value;
+            //ContentColumn.Width = Root.ActualWidth == 0 ? GridLength.Auto : new GridLength(forContent);
+            ContentColumn.MaxWidth = Root.ActualWidth == 0 ? double.MaxValue : forContent;
+            //MainContent.MaxWidth = forContent;
+            Debug.WriteLine($"forContent: {forContent}");
+
+            return;
+
             FrameworkElement clipToElement = MainContent;
             System.Numerics.Vector2 clipToSize = clipToElement.ActualSize;
             Windows.Foundation.Point position = clipToElement.TransformToVisual(this.Content).TransformPoint(new());

--- a/DeskBand11/MainWindow.xaml.cs
+++ b/DeskBand11/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI;
+using Microsoft.CmdPal.Common.Helpers;
 using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
@@ -28,6 +29,7 @@ namespace DeskBand11
         private readonly HWND _hwnd;
         private readonly TrayIconService _trayIconService = new();
         private AppWindow _appWindow;
+        private Tasklist _tasklist;
 
         // Constants for Windows messages related to display changes
         private const int WM_DISPLAYCHANGE = 0x007E;
@@ -62,6 +64,8 @@ namespace DeskBand11
 
             _appWindow = this.AppWindow;
 
+            _tasklist = new Tasklist();
+
             // Set up custom window procedure to listen for display changes
             // LOAD BEARING: If you don't stick the pointer to HotKeyPrc into a
             // member (and instead like, use a local), then the pointer we marshal
@@ -80,7 +84,7 @@ namespace DeskBand11
 
         private void ItemsBar_SizeChanged(object sender, Microsoft.UI.Xaml.SizeChangedEventArgs e)
         {
-            ClipWindow();
+            // ClipWindow();
         }
 
         private void MainWindow_VisibilityChanged(object sender, Microsoft.UI.Xaml.WindowVisibilityChangedEventArgs args)
@@ -154,6 +158,17 @@ namespace DeskBand11
                 return;
             }
 
+            _tasklist.Update();
+            List<TasklistButton> buttons = _tasklist.GetButtons();
+            int maxRight = 0;
+            foreach (TasklistButton button in buttons)
+            {
+                int right = button.X + button.Width;
+                if (right > maxRight) { maxRight = right; }
+            }
+            Debug.WriteLine($"maxRight: {maxRight}");
+            TaskbarButtons.Width = new GridLength(maxRight);
+
             HWND thisWindow = _hwnd;
 
             HWND taskbarWindow = PInvoke.FindWindow("Shell_TrayWnd", null);
@@ -190,7 +205,7 @@ namespace DeskBand11
                          newWindowRect.Height,
                          SET_WINDOW_POS_FLAGS.SWP_FRAMECHANGED | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
 
-            ClipWindow();
+            //ClipWindow();
         }
 
         private void ClipWindow()

--- a/DeskBand11/MainWindow.xaml.cs
+++ b/DeskBand11/MainWindow.xaml.cs
@@ -57,7 +57,7 @@ namespace DeskBand11
 
             // Timer to re-layout based on available space in taskbar
             _updateTaskbarButtonsTimer = DispatcherQueue.CreateTimer();
-            _updateTaskbarButtonsTimer.Tick += (s, e) => UpdateTaskbarButtons();
+            _updateTaskbarButtonsTimer.Tick += (s, e) => ClipWindow();
             _updateTaskbarButtonsTimer.Interval = TimeSpan.FromMilliseconds(500);
             _updateTaskbarButtonsTimer.Start();
 
@@ -252,7 +252,6 @@ namespace DeskBand11
             }
             //ContentColumn.MaxWidth = Root.ActualWidth == 0 ? double.MaxValue : (forContent > 0 ? forContent : 0);
             //MainContent.MaxWidth = forContent;
-            ClipWindow();
         }
         private void ClipWindow()
         {

--- a/DeskBand11/NativeMethods.txt
+++ b/DeskBand11/NativeMethods.txt
@@ -83,3 +83,8 @@ BITMAPINFO
 BITMAPINFOHEADER
 ICONINFO
 HICON
+
+IUIAutomation
+IUIAutomationElement
+IUIAutomationCondition
+UIA_PROPERTY_ID

--- a/DeskBand11/Properties/PublishProfiles/win-arm64.pubxml
+++ b/DeskBand11/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>ARM64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+
+  </PropertyGroup>
+</Project>

--- a/DeskBand11/Properties/PublishProfiles/win-x64.pubxml
+++ b/DeskBand11/Properties/PublishProfiles/win-x64.pubxml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+
+  </PropertyGroup>
+</Project>

--- a/DeskBand11/Properties/PublishProfiles/win-x86.pubxml
+++ b/DeskBand11/Properties/PublishProfiles/win-x86.pubxml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x86</Platform>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+</Project>

--- a/DeskBand11/TaskbarItemViewModel.cs
+++ b/DeskBand11/TaskbarItemViewModel.cs
@@ -47,6 +47,7 @@ namespace DeskBand11
         public partial IconInfo Icon { get; set; } = new(string.Empty);
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(HasText))]
         public partial string Title
         {
             get;
@@ -54,6 +55,7 @@ namespace DeskBand11
         }
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(HasText))]
         public partial string Subtitle { get; set; }
 
         public virtual IProgressState? Progress { get; set; } = null;
@@ -71,6 +73,9 @@ namespace DeskBand11
         ////
         // TODO! BODGY: CmdPal does this better, referencing actual theme
         public bool HasIcon => Icon != null && (!string.IsNullOrEmpty(Icon.Dark.Icon) || Icon.Dark.Data != null);
+        public bool HasTitle => !string.IsNullOrEmpty(Title);
+        public bool HasSubtitle => !string.IsNullOrEmpty(Subtitle);
+        public bool HasText => HasTitle || HasSubtitle;
     }
 
     public partial class CommandViewModel : ObservableObject, ICommand

--- a/DeskBand11/TaskbarItemViewModel.cs
+++ b/DeskBand11/TaskbarItemViewModel.cs
@@ -70,12 +70,15 @@ namespace DeskBand11
 
         IIconInfo ITaskbarItem.HoverPreview => HoverPreview;
 
-        ////
-        // TODO! BODGY: CmdPal does this better, referencing actual theme
+        //// Specifically view stuff 
+        // TODO! BODGY: CmdPal does this better, referencing actual 
         public bool HasIcon => Icon != null && (!string.IsNullOrEmpty(Icon.Dark.Icon) || Icon.Dark.Data != null);
         public bool HasTitle => !string.IsNullOrEmpty(Title);
         public bool HasSubtitle => !string.IsNullOrEmpty(Subtitle);
         public bool HasText => HasTitle || HasSubtitle;
+
+        [ObservableProperty]
+        public partial bool ShouldBeVisible { get; set; } = true;
     }
 
     public partial class CommandViewModel : ObservableObject, ICommand

--- a/DeskBand11/cmdpal/TasklistButton.cs
+++ b/DeskBand11/cmdpal/TasklistButton.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -136,7 +135,7 @@ public sealed partial class Tasklist : IDisposable
                 if (button != null)
                 {
                     foundButtons.Add(button);
-                    Debug.WriteLine($"  button: {button.Name}");
+                    // Debug.WriteLine($"  button: {button.Name}");
                 }
 
                 Marshal.ReleaseComObject(child);

--- a/DeskBand11/cmdpal/TasklistButton.cs
+++ b/DeskBand11/cmdpal/TasklistButton.cs
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.UI.Accessibility;
+
+namespace Microsoft.CmdPal.Common.Helpers;
+
+/// <summary>
+/// Represents a button on the Windows taskbar.
+/// </summary>
+public sealed record TasklistButton
+{
+    /// <summary>
+    /// Gets the name/automation ID of the taskbar button.
+    /// </summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the X coordinate of the button.
+    /// </summary>
+    public int X { get; init; }
+
+    /// <summary>
+    /// Gets the Y coordinate of the button.
+    /// </summary>
+    public int Y { get; init; }
+
+    /// <summary>
+    /// Gets the width of the button.
+    /// </summary>
+    public int Width { get; init; }
+
+    /// <summary>
+    /// Gets the height of the button.
+    /// </summary>
+    public int Height { get; init; }
+
+    /// <summary>
+    /// Gets the assigned key number for the button (1-10).
+    /// </summary>
+    public int KeyNum { get; init; }
+}
+
+/// <summary>
+/// Provides functionality to interact with and retrieve information about Windows taskbar buttons.
+/// </summary>
+public sealed partial class Tasklist : IDisposable
+{
+    private IUIAutomation? _automation;
+    private IUIAutomationElement? _element;
+    private IUIAutomationCondition? _trueCondition;
+    private bool _disposed;
+
+    /// <summary>
+    /// Updates the internal references to the Windows taskbar.
+    /// </summary>
+    public void Update()
+    {
+        ThrowIfDisposed();
+
+        // Get HWND of the tasklist by walking the window hierarchy
+        HWND tasklistHwnd = PInvoke.FindWindow("Shell_TrayWnd", null);
+        if (tasklistHwnd.IsNull)
+        {
+            return;
+        }
+
+        tasklistHwnd = PInvoke.FindWindowEx(tasklistHwnd, HWND.Null, "ReBarWindow32", null);
+        if (tasklistHwnd.IsNull)
+        {
+            return;
+        }
+
+        tasklistHwnd = PInvoke.FindWindowEx(tasklistHwnd, HWND.Null, "MSTaskSwWClass", null);
+        if (tasklistHwnd.IsNull)
+        {
+            return;
+        }
+
+        tasklistHwnd = PInvoke.FindWindowEx(tasklistHwnd, HWND.Null, "MSTaskListWClass", null);
+        if (tasklistHwnd.IsNull)
+        {
+            return;
+        }
+
+        // Initialize UI Automation if not already done
+        if (_automation == null)
+        {
+            _automation = (IUIAutomation)new CUIAutomation();
+            _trueCondition = _automation.CreateTrueCondition();
+        }
+
+        // Get the automation element for the taskbar
+        _element = _automation.ElementFromHandle(tasklistHwnd);
+    }
+
+    /// <summary>
+    /// Updates the provided list with current taskbar buttons.
+    /// </summary>
+    /// <param name="buttons">The list to populate with taskbar buttons.</param>
+    /// <returns>True if successful, false otherwise.</returns>
+    public bool UpdateButtons(List<TasklistButton> buttons)
+    {
+        ThrowIfDisposed();
+
+        if (_automation == null || _element == null || _trueCondition == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            IUIAutomationElementArray elements = _element.FindAll(TreeScope.TreeScope_Children, _trueCondition);
+            if (elements == null)
+            {
+                return false;
+            }
+
+            int count = elements.Length;
+            List<TasklistButton> foundButtons = new(count);
+
+            for (int i = 0; i < count; i++)
+            {
+                IUIAutomationElement child = elements.GetElement(i);
+                if (child == null)
+                {
+                    continue;
+                }
+
+                TasklistButton? button = CreateTasklistButton(child);
+                if (button != null)
+                {
+                    foundButtons.Add(button);
+                    Debug.WriteLine($"  button: {button.Name}");
+                }
+
+                Marshal.ReleaseComObject(child);
+            }
+
+            Marshal.ReleaseComObject(elements);
+
+            // Assign key numbers and filter buttons
+            AssignKeyNumbers(foundButtons, buttons);
+            return true;
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current taskbar buttons.
+    /// </summary>
+    /// <returns>A list of taskbar buttons.</returns>
+    public List<TasklistButton> GetButtons()
+    {
+        List<TasklistButton> buttons = new();
+        UpdateButtons(buttons);
+        return buttons;
+    }
+
+    /// <summary>
+    /// Creates a TasklistButton from a UI automation element.
+    /// </summary>
+    /// <param name="element">The UI automation element.</param>
+    /// <returns>A TasklistButton if successful, null otherwise.</returns>
+    private static TasklistButton? CreateTasklistButton(IUIAutomationElement element)
+    {
+        try
+        {
+            // Get bounding rectangle
+            object boundingRect = element.GetCurrentPropertyValue(UIA_PROPERTY_ID.UIA_BoundingRectanglePropertyId);
+            double[]? rectArray = boundingRect as double[];
+            if (rectArray is null)
+            {
+                return null;
+            }
+            //if (boundingRect == null || !boundingRect.IsArray)
+            //    return null;
+
+            //var rectArray = (double[])boundingRect;
+            if (rectArray.Length < 4)
+            {
+                return null;
+            }
+
+            // Get automation ID (name)
+
+            string automationId = element.CurrentAutomationId.ToString() ?? string.Empty;
+
+            return new TasklistButton
+            {
+                Name = automationId,
+                X = (int)rectArray[0],
+                Y = (int)rectArray[1],
+                Width = (int)rectArray[2],
+                Height = (int)rectArray[3],
+                KeyNum = 0 // Will be assigned later
+            };
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Assigns key numbers to buttons and filters the result.
+    /// </summary>
+    /// <param name="foundButtons">The buttons found via automation.</param>
+    /// <param name="buttons">The output list to populate.</param>
+    private static void AssignKeyNumbers(List<TasklistButton> foundButtons, List<TasklistButton> buttons)
+    {
+        buttons.Clear();
+
+        foreach (TasklistButton button in foundButtons)
+        {
+            if (buttons.Count == 0)
+            {
+                buttons.Add(button with { KeyNum = 1 });
+            }
+            else
+            {
+                TasklistButton lastButton = buttons[^1];
+
+                // Skip buttons on second row (lower Y coordinate or significantly left of previous)
+                if (button.X < lastButton.X || button.Y < lastButton.Y)
+                {
+                    break;
+                }
+
+                // Skip buttons from the same app (same name)
+                if (button.Name == lastButton.Name)
+                {
+                    continue;
+                }
+
+                int nextKeyNum = lastButton.KeyNum + 1;
+                buttons.Add(button with { KeyNum = nextKeyNum });
+
+                // Limit to 10 buttons
+                if (nextKeyNum == 10)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Throws an ObjectDisposedException if the object has been disposed.
+    /// </summary>
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(Tasklist));
+        }
+    }
+
+    /// <summary>
+    /// Releases the COM objects used by this instance.
+    /// </summary>
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            if (_trueCondition != null)
+            {
+                Marshal.ReleaseComObject(_trueCondition);
+                _trueCondition = null;
+            }
+
+            if (_element != null)
+            {
+                Marshal.ReleaseComObject(_element);
+                _element = null;
+            }
+
+            if (_automation != null)
+            {
+                Marshal.ReleaseComObject(_automation);
+                _automation = null;
+            }
+
+            _disposed = true;
+        }
+    }
+}
+
+/// <summary>
+/// COM class for UI Automation.
+/// </summary>
+[ComImport]
+[Guid("ff48dba4-60ef-4201-aa87-54103eef594e")]
+internal class CUIAutomation
+{
+}


### PR DESCRIPTION
Not perfect, but good enough.

Uses the code from shortcut guide to use UIA to detect where the buttons are on the taskbar. If we're too fat for the taskbar, we'll collapse items down so that they fit. 

Adds an overflow menu for when things don't fit. 